### PR TITLE
Limbo auth reading uppercased columns instead of lowercase

### DIFF
--- a/auth/src/main/java/net/elytrium/limboauth/handler/AuthSessionHandler.java
+++ b/auth/src/main/java/net/elytrium/limboauth/handler/AuthSessionHandler.java
@@ -133,7 +133,7 @@ public class AuthSessionHandler implements LimboSessionHandler {
   public static RegisteredPlayer fetchInfo(Dao<RegisteredPlayer, String> playerDao, String nickname) {
     List<RegisteredPlayer> playerList = null;
     try {
-      playerList = playerDao.queryForEq("NICKNAME", nickname);
+      playerList = playerDao.queryForEq("nickname", nickname);
     } catch (SQLException e) {
       e.printStackTrace();
     }

--- a/auth/src/main/java/net/elytrium/limboauth/handler/AuthSessionHandler.java
+++ b/auth/src/main/java/net/elytrium/limboauth/handler/AuthSessionHandler.java
@@ -171,7 +171,7 @@ public class AuthSessionHandler implements LimboSessionHandler {
 
   private void checkIp() {
     try {
-      List<RegisteredPlayer> alreadyRegistered = this.playerDao.queryForEq("IP", this.ip);
+      List<RegisteredPlayer> alreadyRegistered = this.playerDao.queryForEq("ip", this.ip);
 
       if (alreadyRegistered == null) {
         return;


### PR DESCRIPTION
Limbo-Auth is currently reading columns as "IP" and "NICKNAME" instead of "ip" and "nickname" as displayed in the database. This has caused issues with Postgres. This PR should fix the issue and it shouldn't cause any other issues with MySQL and other databases.

Fixes #15