### PR TITLE
Add the ability to set player game modes

### DIFF
--- a/api/src/main/java/net/elytrium/limboapi/api/player/GameMode.java
+++ b/api/src/main/java/net/elytrium/limboapi/api/player/GameMode.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2021 Elytrium
+ *
+ * The LimboAPI (excluding the LimboAPI plugin) is licensed under the terms of the MIT License. For more details,
+ * reference the LICENSE file in the api top-level directory.
+ */
+
+package net.elytrium.limboapi.api.player;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+public enum GameMode {
+  SURVIVAL,
+  CREATIVE,
+  ADVENTURE,
+  SPECTATOR;
+  /**
+   * Cached {@link #values()} array to avoid constant array allocation.
+   */
+  private static final GameMode[] VALUES = values();
+
+  /**
+   * Get the ID of this {@link GameMode}.
+   *
+   * @return The ID.
+   * @see #getById(int)
+   */
+  public int getId() {
+    return this.ordinal();
+  }
+
+  /**
+   * Get a {@link GameMode} by its' ID.
+   *
+   * @param id The ID.
+   * @return The {@link GameMode}, or {@code null} if it does not exist.
+   * @see #getId()
+   */
+  public static @Nullable GameMode getById(int id) {
+    return VALUES[id];
+  }
+}

--- a/api/src/main/java/net/elytrium/limboapi/api/player/LimboPlayer.java
+++ b/api/src/main/java/net/elytrium/limboapi/api/player/LimboPlayer.java
@@ -31,6 +31,8 @@ public interface LimboPlayer {
 
   void setInventory(int slot, VirtualItem item, int count, int data, CompoundBinaryTag nbt);
 
+  void setGameMode(GameMode gameMode);
+
   void teleport(double x, double y, double z, float yaw, float pitch);
 
   void sendTitle(Component title, Component subtitle, ProtocolVersion version, int fadeIn, int stay, int fadeOut);

--- a/api/src/main/java/net/elytrium/limboapi/api/protocol/packets/BuiltInPackets.java
+++ b/api/src/main/java/net/elytrium/limboapi/api/protocol/packets/BuiltInPackets.java
@@ -10,6 +10,7 @@ package net.elytrium.limboapi.api.protocol.packets;
 @SuppressWarnings("unused")
 public enum BuiltInPackets {
 
+  ChangeGameState("net.elytrium.limboapi.protocol.packet.ChangeGameState"),
   ChunkData("net.elytrium.limboapi.protocol.packet.world.ChunkData"),
   MapData("net.elytrium.limboapi.protocol.packet.MapDataPacket"),
   Player("net.elytrium.limboapi.protocol.packet.Player"),

--- a/plugin/src/main/java/net/elytrium/limboapi/protocol/LimboProtocol.java
+++ b/plugin/src/main/java/net/elytrium/limboapi/protocol/LimboProtocol.java
@@ -54,6 +54,7 @@ import java.util.List;
 import java.util.function.Supplier;
 import net.elytrium.limboapi.api.protocol.PacketDirection;
 import net.elytrium.limboapi.api.protocol.packets.PacketMapping;
+import net.elytrium.limboapi.protocol.packet.ChangeGameState;
 import net.elytrium.limboapi.protocol.packet.MapDataPacket;
 import net.elytrium.limboapi.protocol.packet.Player;
 import net.elytrium.limboapi.protocol.packet.PlayerAbilities;
@@ -232,6 +233,12 @@ public class LimboProtocol {
             map(0x40, ProtocolVersion.MINECRAFT_1_16, true),
             map(0x49, ProtocolVersion.MINECRAFT_1_17, true)
         });
+    register(PacketDirection.CLIENTBOUND,
+            ChangeGameState.class, ChangeGameState::new,
+            new StateRegistry.PacketMapping[] {
+                    map(0x2B, ProtocolVersion.MINECRAFT_1_7_2, true),
+                    map(0x1E, ProtocolVersion.MINECRAFT_1_9, true)
+            });
 
     register(PacketDirection.SERVERBOUND,
         TabCompleteRequest.class, TabCompleteRequest::new,

--- a/plugin/src/main/java/net/elytrium/limboapi/protocol/packet/ChangeGameState.java
+++ b/plugin/src/main/java/net/elytrium/limboapi/protocol/packet/ChangeGameState.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2021 Elytrium
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package net.elytrium.limboapi.protocol.packet;
+
+import com.velocitypowered.api.network.ProtocolVersion;
+import com.velocitypowered.proxy.connection.MinecraftSessionHandler;
+import com.velocitypowered.proxy.protocol.MinecraftPacket;
+import com.velocitypowered.proxy.protocol.ProtocolUtils;
+import io.netty.buffer.ByteBuf;
+
+public class ChangeGameState implements MinecraftPacket {
+
+  private final int reason;
+  private final float value;
+
+  public ChangeGameState(int reason, float value) {
+    this.reason = reason;
+    this.value = value;
+  }
+
+  public ChangeGameState() {
+    throw new IllegalStateException();
+  }
+
+  @Override
+  public void decode(ByteBuf buf, ProtocolUtils.Direction direction, ProtocolVersion protocolVersion) {
+  }
+
+  @Override
+  public void encode(ByteBuf buf, ProtocolUtils.Direction direction, ProtocolVersion protocolVersion) {
+    buf.writeByte(this.reason);
+    buf.writeFloat(this.value);
+  }
+
+  @Override
+  public boolean handle(MinecraftSessionHandler handler) {
+    return true;
+  }
+
+  @Override
+  public String toString() {
+    return "ChangeGameState{"
+            + "reason=" + this.reason
+            + ", value=" + this.value
+            + '}';
+  }
+}

--- a/plugin/src/main/java/net/elytrium/limboapi/server/LimboPlayerImpl.java
+++ b/plugin/src/main/java/net/elytrium/limboapi/server/LimboPlayerImpl.java
@@ -27,9 +27,11 @@ import java.awt.image.BufferedImage;
 import net.elytrium.limboapi.LimboApi;
 import net.elytrium.limboapi.api.Limbo;
 import net.elytrium.limboapi.api.material.VirtualItem;
+import net.elytrium.limboapi.api.player.GameMode;
 import net.elytrium.limboapi.api.player.LimboPlayer;
 import net.elytrium.limboapi.api.protocol.map.MapPalette;
 import net.elytrium.limboapi.api.protocol.packets.data.MapData;
+import net.elytrium.limboapi.protocol.packet.ChangeGameState;
 import net.elytrium.limboapi.protocol.packet.MapDataPacket;
 import net.elytrium.limboapi.protocol.packet.PlayerAbilities;
 import net.elytrium.limboapi.protocol.packet.PlayerPositionAndLook;
@@ -96,6 +98,14 @@ public class LimboPlayerImpl implements LimboPlayer {
   @Override
   public void setInventory(int slot, VirtualItem item, int count, int data, CompoundBinaryTag nbt) {
     this.player.getConnection().write(new SetSlot(0, slot, item, count, data, nbt));
+  }
+
+  @Override
+  public void setGameMode(GameMode gameMode) {
+    if (gameMode == GameMode.SPECTATOR && this.player.getProtocolVersion().compareTo(ProtocolVersion.MINECRAFT_1_8) < 0) {
+      return; // Spectator game mode was added in 1.8
+    }
+    this.player.getConnection().write(new ChangeGameState(3, gameMode.getId()));
   }
 
   @Override


### PR DESCRIPTION
- Added `LimboPlayer#setGameMode(GameMode)`.
- Added the `GameMode` enum.
- Implemented the `ChangeGameState` packet.

Tested on 1.8.9 and 1.18.1.