### PR TITLE
Retain packets before adding them to the queue

### DIFF
--- a/plugin/src/main/java/net/elytrium/limboapi/injection/login/LoginTrackHandler.java
+++ b/plugin/src/main/java/net/elytrium/limboapi/injection/login/LoginTrackHandler.java
@@ -59,7 +59,7 @@ public class LoginTrackHandler implements MinecraftSessionHandler {
   @Override
   public void handleGeneric(MinecraftPacket packet) {
     if (this.connection.getState() == StateRegistry.CONFIG) {
-      this.queuedPackets.add(packet);
+      this.queuedPackets.add(ReferenceCountUtil.retain(packet));
     }
   }
 


### PR DESCRIPTION
As `MinecraftConnection` is releasing packets, they should be retained by `LoginTrackHandler` before adding them to the queue.