### PR TITLE
Synchronize transition from PLAY to CONFIG state

### DIFF
--- a/plugin/src/main/java/net/elytrium/limboapi/injection/login/LoginListener.java
+++ b/plugin/src/main/java/net/elytrium/limboapi/injection/login/LoginListener.java
@@ -76,6 +76,8 @@ import net.elytrium.limboapi.api.event.LoginLimboRegisterEvent;
 import net.elytrium.limboapi.injection.dummy.ClosedChannel;
 import net.elytrium.limboapi.injection.dummy.ClosedMinecraftConnection;
 import net.elytrium.limboapi.injection.dummy.DummyEventPool;
+import net.elytrium.limboapi.injection.login.confirmation.ConfirmHandler;
+import net.elytrium.limboapi.injection.login.confirmation.LoginConfirmHandler;
 import net.elytrium.limboapi.injection.packet.ServerLoginSuccessHook;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
@@ -134,7 +136,7 @@ public class LoginListener {
       MC_CONNECTION_FIELD.set(handler, CLOSED_MINECRAFT_CONNECTION);
 
       if (connection.getProtocolVersion().compareTo(ProtocolVersion.MINECRAFT_1_20_2) >= 0) {
-        connection.setActiveSessionHandler(StateRegistry.LOGIN, new LoginTrackHandler(connection));
+        connection.setActiveSessionHandler(StateRegistry.LOGIN, new LoginConfirmHandler(connection));
       }
 
       // From Velocity.
@@ -151,7 +153,7 @@ public class LoginListener {
                 inboundConnection.getIdentifiedKey()
             );
             if (connection.getProtocolVersion().compareTo(ProtocolVersion.MINECRAFT_1_20_2) >= 0) {
-              ((LoginTrackHandler) connection.getActiveSessionHandler()).setPlayer(player);
+              ((ConfirmHandler) connection.getActiveSessionHandler()).setPlayer(player);
             }
             if (this.server.canRegisterConnection(player)) {
               if (!connection.isClosed()) {

--- a/plugin/src/main/java/net/elytrium/limboapi/injection/login/confirmation/LoginConfirmHandler.java
+++ b/plugin/src/main/java/net/elytrium/limboapi/injection/login/confirmation/LoginConfirmHandler.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2021 - 2023 Elytrium
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package net.elytrium.limboapi.injection.login.confirmation;
+
+import com.velocitypowered.proxy.connection.MinecraftConnection;
+import com.velocitypowered.proxy.protocol.StateRegistry;
+import com.velocitypowered.proxy.protocol.packet.LoginAcknowledged;
+import io.netty.buffer.ByteBuf;
+
+public class LoginConfirmHandler extends ConfirmHandler {
+
+  public LoginConfirmHandler(MinecraftConnection connection) {
+    super(connection);
+  }
+
+  @Override
+  public boolean handle(LoginAcknowledged packet) {
+    this.connection.setState(StateRegistry.CONFIG);
+    this.confirmation.complete(this);
+    return true;
+  }
+
+  @Override
+  public void handleUnknown(ByteBuf buf) {
+    this.connection.close(true);
+  }
+}

--- a/plugin/src/main/java/net/elytrium/limboapi/injection/login/confirmation/TransitionConfirmHandler.java
+++ b/plugin/src/main/java/net/elytrium/limboapi/injection/login/confirmation/TransitionConfirmHandler.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2021 - 2023 Elytrium
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package net.elytrium.limboapi.injection.login.confirmation;
+
+import com.velocitypowered.proxy.connection.MinecraftConnection;
+import com.velocitypowered.proxy.protocol.StateRegistry;
+import com.velocitypowered.proxy.protocol.packet.config.FinishedUpdate;
+
+public class TransitionConfirmHandler extends ConfirmHandler {
+
+  public TransitionConfirmHandler(MinecraftConnection connection) {
+    super(connection);
+  }
+
+  @Override
+  public boolean handle(FinishedUpdate packet) {
+    if (this.connection.getState() == StateRegistry.PLAY) {
+      this.connection.setState(StateRegistry.CONFIG);
+      this.confirmation.complete(this);
+      return true;
+    }
+
+    return false;
+  }
+}

--- a/plugin/src/main/java/net/elytrium/limboapi/server/LimboImpl.java
+++ b/plugin/src/main/java/net/elytrium/limboapi/server/LimboImpl.java
@@ -90,7 +90,7 @@ import net.elytrium.limboapi.api.player.GameMode;
 import net.elytrium.limboapi.api.protocol.PacketDirection;
 import net.elytrium.limboapi.api.protocol.PreparedPacket;
 import net.elytrium.limboapi.api.protocol.packets.PacketMapping;
-import net.elytrium.limboapi.injection.login.LoginTrackHandler;
+import net.elytrium.limboapi.injection.login.confirmation.ConfirmHandler;
 import net.elytrium.limboapi.injection.packet.MinecraftLimitedCompressDecoder;
 import net.elytrium.limboapi.material.Biome;
 import net.elytrium.limboapi.protocol.LimboProtocol;
@@ -414,9 +414,9 @@ public class LimboImpl implements Limbo {
           () -> this.limboName
       );
 
-      if (connection.getActiveSessionHandler() instanceof LoginTrackHandler) {
-        LoginTrackHandler track = (LoginTrackHandler) connection.getActiveSessionHandler();
-        track.waitForConfirmation(() -> {
+      if (connection.getActiveSessionHandler() instanceof ConfirmHandler) {
+        ConfirmHandler confirm = (ConfirmHandler) connection.getActiveSessionHandler();
+        confirm.waitForConfirmation(() -> {
           this.spawnPlayerLocal(handlerClass, sessionHandler, player, connection);
         });
       } else {


### PR DESCRIPTION
As the client _can send packets_,  transition should be synchronized then switching to CONFIG state.