### PR TITLE
Use LambdaMetafactory instead of classic reflection whenever possible

### DIFF
--- a/plugin/src/main/java/net/elytrium/limboapi/injection/tablist/RewritingVelocityTabList.java
+++ b/plugin/src/main/java/net/elytrium/limboapi/injection/tablist/RewritingVelocityTabList.java
@@ -26,15 +26,18 @@ import java.lang.reflect.Field;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.function.Function;
+import net.elytrium.limboapi.utils.LambdaUtil;
 
 public class RewritingVelocityTabList extends VelocityTabList implements RewritingTabList {
 
-  private static final Field ENTRIES;
+  private static final Function<VelocityTabList, Map<UUID, VelocityTabListEntry>> ENTRIES_GETTER;
 
   static {
     try {
-      ENTRIES = VelocityTabList.class.getDeclaredField("entries");
-      ENTRIES.setAccessible(true);
+      Field field = VelocityTabList.class.getDeclaredField("entries");
+      field.setAccessible(true);
+      ENTRIES_GETTER = LambdaUtil.getterOf(field);
     } catch (Throwable throwable) {
       throw new ExceptionInInitializerError(throwable);
     }
@@ -50,7 +53,7 @@ public class RewritingVelocityTabList extends VelocityTabList implements Rewriti
     try {
       this.player = player;
       this.connection = player.getConnection();
-      this.entries = (Map<UUID, VelocityTabListEntry>) ENTRIES.get(this);
+      this.entries = ENTRIES_GETTER.apply(this);
     } catch (Throwable e) {
       throw new IllegalStateException(e);
     }

--- a/plugin/src/main/java/net/elytrium/limboapi/utils/LambdaUtil.java
+++ b/plugin/src/main/java/net/elytrium/limboapi/utils/LambdaUtil.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2021 - 2024 Elytrium
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package net.elytrium.limboapi.utils;
 
 import java.lang.invoke.LambdaMetafactory;

--- a/plugin/src/main/java/net/elytrium/limboapi/utils/LambdaUtil.java
+++ b/plugin/src/main/java/net/elytrium/limboapi/utils/LambdaUtil.java
@@ -1,0 +1,41 @@
+package net.elytrium.limboapi.utils;
+
+import java.lang.invoke.LambdaMetafactory;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.reflect.Field;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+
+public final class LambdaUtil {
+  private static final MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
+
+  public static <T, R> Function<T, R> getterOf(Field field) throws Throwable {
+    MethodHandle handle = LOOKUP.unreflectGetter(field);
+    MethodType type = handle.type();
+    //noinspection unchecked
+    return (Function<T, R>) LambdaMetafactory.metafactory(
+        LOOKUP,
+        "apply",
+        MethodType.methodType(Function.class, MethodHandle.class),
+        type.generic(),
+        MethodHandles.exactInvoker(type),
+        type
+    ).getTarget().invokeExact(handle);
+  }
+
+  public static <T, R> BiConsumer<T, R> setterOf(Field f) throws Throwable {
+    MethodHandle handle = LOOKUP.unreflectSetter(f);
+    MethodType type = handle.type();
+    //noinspection unchecked
+    return (BiConsumer<T, R>) LambdaMetafactory.metafactory(
+        LOOKUP,
+        "accept",
+        MethodType.methodType(BiConsumer.class, MethodHandle.class),
+        type.generic().changeReturnType(void.class),
+        MethodHandles.exactInvoker(type),
+        type
+    ).getTarget().invokeExact(handle);
+  }
+}


### PR DESCRIPTION
LambdaMetafactory 10% slower than a static MethodHandle but 80% faster than a non-static MethodHandle & Reflection

Replaced frequent reflection call to the constant field [DEFAULT_PERMISSIONS](https://github.com/breitwan/LimboAPI/commit/fa30bbb02eefb0c20bf03ffe655ea75aaca60f99#diff-cf259b28bb12e9297437824b50c77a0b3b9403e1186b34f005787c580a051f6f) by own constant
Removed hacky use of sun.misc.Unsafe from [LoginListener.java](https://github.com/breitwan/LimboAPI/commit/fa30bbb02eefb0c20bf03ffe655ea75aaca60f99#diff-052458e3396a0d040597a9d4532b1e3b8ce31206f876790e7bfebb95fc81e1b7)
LMF is not used in one-shot things like [LimboProtocol.java](https://github.com/Elytrium/LimboAPI/blob/master/plugin/src/main/java/net/elytrium/limboapi/protocol/LimboProtocol.java)

https://stackoverflow.com/questions/19557829/faster-alternatives-to-javas-reflection/19563000#19563000
https://www.optaplanner.org/blog/2018/01/09/JavaReflectionButMuchFaster.html
https://mail.openjdk.org/pipermail/mlvm-dev/2018-February/006817.html