### PR TITLE
Migrate to build-logic convention plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,6 +85,7 @@ $RECYCLE.BIN/
 
 # Gradle
 .gradle
+.kotlin
 build/
 
 # Gradle Patch

--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -7,11 +7,14 @@ import org.gradle.kotlin.dsl.closureOf
 plugins {
     `java-library`
     `maven-publish`
-}
-
-tasks.withType<JavaCompile> {
-    options.release.set(21)
-    options.encoding = "UTF-8"
+    alias(libs.plugins.gradle.spotbugs)
+    alias(libs.plugins.gradle.licenser)
+    id("net.elytrium.java.version")
+    id("net.elytrium.module.info")
+    id("net.elytrium.revision")
+    id("net.elytrium.spotbugs")
+    id("net.elytrium.checkstyle")
+    id("net.elytrium.licence")
 }
 
 dependencies {
@@ -23,16 +26,6 @@ dependencies {
     api(libs.minecraft.adventure.nbt)
 
     compileOnly(libs.tool.spotbugs.annotations)
-}
-
-extensions.configure<LicenseExtension> {
-    matching(
-        "**/mcprotocollib/**",
-        closureOf<LicenseProperties> {
-            setHeader(rootProject.file("HEADER_MCPROTOCOLLIB.txt"))
-        }
-    )
-    setHeader(file("HEADER.txt"))
 }
 
 tasks.named<Javadoc>("javadoc") {
@@ -82,13 +75,10 @@ artifacts {
     archives(sourcesJar)
 }
 
-@Suppress("UNCHECKED_CAST")
-val getCurrentShortRevision = rootProject.extra["getCurrentShortRevision"] as () -> String
-
-
 val versionStringProvider = provider {
     if (version.toString().contains("-")) {
-        "${version} (git-${getCurrentShortRevision()})"
+        val currentShortRevision = currentShortRevisionProvider.getCurrentShortRevision()
+        "${version} (git-${currentShortRevision})"
     } else {
         version.toString()
     }

--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -1,20 +1,17 @@
 @file:Suppress("GroovyAssignabilityCheck")
 
-import net.minecraftforge.licenser.LicenseExtension
-import net.minecraftforge.licenser.LicenseProperties
-import org.gradle.kotlin.dsl.closureOf
-
 plugins {
     `java-library`
     `maven-publish`
-    alias(libs.plugins.gradle.spotbugs)
     alias(libs.plugins.gradle.licenser)
+    alias(libs.plugins.gradle.spotbugs)
+    id("net.elytrium.checkstyle")
     id("net.elytrium.java.version")
+    id("net.elytrium.licence")
     id("net.elytrium.module.info")
+    id("net.elytrium.publish")
     id("net.elytrium.revision")
     id("net.elytrium.spotbugs")
-    id("net.elytrium.checkstyle")
-    id("net.elytrium.licence")
 }
 
 dependencies {
@@ -26,53 +23,6 @@ dependencies {
     api(libs.minecraft.adventure.nbt)
 
     compileOnly(libs.tool.spotbugs.annotations)
-}
-
-tasks.named<Javadoc>("javadoc") {
-    options.encoding = "UTF-8"
-    (options as? StandardJavadocDocletOptions)?.apply {
-        source = "21"
-        links("https://docs.oracle.com/en/java/javase/11/docs/api/")
-        addStringOption("Xdoclint:none", "-quiet")
-        if (JavaVersion.current() >= JavaVersion.VERSION_1_9 && JavaVersion.current() < JavaVersion.VERSION_12) {
-            addBooleanOption("-no-module-directories", true)
-        }
-    }
-}
-
-val sourcesJar by tasks.registering(Jar::class) {
-    archiveClassifier.set("sources")
-    from(sourceSets.main.get().allSource)
-}
-
-val javadocJar by tasks.registering(Jar::class) {
-    archiveClassifier.set("javadoc")
-    from(tasks.javadoc)
-}
-
-publishing {
-    repositories {
-        maven {
-            credentials {
-                username = System.getenv("ELYTRIUM_MAVEN_USERNAME")
-                password = System.getenv("ELYTRIUM_MAVEN_PASSWORD")
-            }
-            name = "elytrium-repo"
-            url = uri("https://maven.elytrium.net/repo/")
-        }
-    }
-
-    publications.create<MavenPublication>("publication") {
-        from(components["java"])
-
-        artifact(javadocJar)
-        artifact(sourcesJar)
-    }
-}
-
-artifacts {
-    archives(javadocJar)
-    archives(sourcesJar)
 }
 
 val versionStringProvider = provider {

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -1,0 +1,40 @@
+plugins {
+    `kotlin-dsl`
+    id("java-gradle-plugin")
+}
+
+dependencies {
+    implementation(files(libs.javaClass.superclass.protectionDomain.codeSource.location))
+    implementation(libs.gradle.spotbugs)
+    implementation(libs.gradle.licenser)
+}
+
+gradlePlugin {
+    plugins {
+        create("net.elytrium.java.version") {
+            id = name
+            implementationClass = "net.elytrium.gradle.plugin.JavaVersionPlugin"
+        }
+
+        create("net.elytrium.module.info") {
+            id = name
+            implementationClass = "net.elytrium.gradle.plugin.ModuleInfoPlugin"
+        }
+        create("net.elytrium.revision") {
+            id = name
+            implementationClass = "net.elytrium.gradle.plugin.revision.CurrentRevisionPlugin"
+        }
+        create("net.elytrium.spotbugs") {
+            id = name
+            implementationClass = "net.elytrium.gradle.plugin.SpotBugsConfigurationPlugin"
+        }
+        create("net.elytrium.checkstyle") {
+            id = name
+            implementationClass = "net.elytrium.gradle.plugin.CheckstyleConfigurationPlugin"
+        }
+        create("net.elytrium.licence") {
+            id = name
+            implementationClass = "net.elytrium.gradle.plugin.LicenceConfigurationPlugin"
+        }
+    }
+}

--- a/build-logic/convention/src/main/kotlin/net.elytrium.publish.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/net.elytrium.publish.gradle.kts
@@ -1,0 +1,52 @@
+plugins {
+    id("java")
+    id("java-library")
+    id("maven-publish")
+}
+
+tasks.named<Javadoc>("javadoc") {
+    options.encoding = "UTF-8"
+    (options as? StandardJavadocDocletOptions)?.apply {
+        source = "21"
+        links("https://docs.oracle.com/en/java/javase/11/docs/api/")
+        addStringOption("Xdoclint:none", "-quiet")
+        if (JavaVersion.current() >= JavaVersion.VERSION_1_9 && JavaVersion.current() < JavaVersion.VERSION_12) {
+            addBooleanOption("-no-module-directories", true)
+        }
+    }
+}
+
+val sourcesJar by tasks.registering(Jar::class) {
+    archiveClassifier.set("sources")
+    from(sourceSets.main.get().allSource)
+}
+
+val javadocJar by tasks.registering(Jar::class) {
+    archiveClassifier.set("javadoc")
+    from(tasks.javadoc)
+}
+
+publishing {
+    repositories {
+        maven {
+            credentials {
+                username = System.getenv("ELYTRIUM_MAVEN_USERNAME")
+                password = System.getenv("ELYTRIUM_MAVEN_PASSWORD")
+            }
+            name = "elytrium-repo"
+            url = uri("https://maven.elytrium.net/repo/")
+        }
+    }
+
+    publications.create<MavenPublication>("publication") {
+        from(components["java"])
+
+        artifact(javadocJar)
+        artifact(sourcesJar)
+    }
+}
+
+artifacts {
+    archives(javadocJar)
+    archives(sourcesJar)
+}

--- a/build-logic/convention/src/main/kotlin/net/elytrium/gradle/plugin/CheckstyleConfigurationPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/net/elytrium/gradle/plugin/CheckstyleConfigurationPlugin.kt
@@ -1,0 +1,21 @@
+package net.elytrium.gradle.plugin
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.plugins.quality.CheckstyleExtension
+import org.gradle.kotlin.dsl.configure
+
+class CheckstyleConfigurationPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        target.plugins.apply("checkstyle")
+        target.pluginManager.withPlugin("checkstyle") {
+            target.configure<CheckstyleExtension> {
+                toolVersion = "10.12.1"
+                configFile = target.file("${target.rootDir}/config/checkstyle/checkstyle.xml")
+                configProperties = mapOf("configDirectory" to "${target.rootDir}/config/checkstyle")
+                maxErrors = 0
+                maxWarnings = 0
+            }
+        }
+    }
+}

--- a/build-logic/convention/src/main/kotlin/net/elytrium/gradle/plugin/JavaVersionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/net/elytrium/gradle/plugin/JavaVersionPlugin.kt
@@ -1,0 +1,20 @@
+package net.elytrium.gradle.plugin
+
+import org.gradle.api.JavaVersion
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.tasks.compile.JavaCompile
+import org.gradle.kotlin.dsl.withType
+
+class JavaVersionPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        target.pluginManager.withPlugin("java") {
+            target.tasks.withType<JavaCompile> {
+                sourceCompatibility = JavaVersion.VERSION_21.toString()
+                targetCompatibility = JavaVersion.VERSION_21.toString()
+                options.release.set(21)
+                options.encoding = "UTF-8"
+            }
+        }
+    }
+}

--- a/build-logic/convention/src/main/kotlin/net/elytrium/gradle/plugin/LicenceConfigurationPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/net/elytrium/gradle/plugin/LicenceConfigurationPlugin.kt
@@ -1,0 +1,41 @@
+package net.elytrium.gradle.plugin
+
+import net.minecraftforge.licenser.LicenseExtension
+import net.minecraftforge.licenser.LicenseProperties
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.closureOf
+import org.gradle.kotlin.dsl.configure
+import java.io.File
+
+class LicenceConfigurationPlugin : Plugin<Project> {
+
+    private fun getHeaderFile(target: Project): File {
+        return target.file("HEADER.txt")
+            .takeIf(File::exists)
+            ?: target.rootProject.file("HEADER.txt")
+    }
+
+    override fun apply(target: Project) {
+        target.pluginManager.withPlugin("net.minecraftforge.licenser") {
+            target.extensions.configure<LicenseExtension> {
+                mapOf(
+                    "**/mcprotocollib/**" to "HEADER_MCPROTOCOLLIB.txt",
+                    "**/LoginListener.java" to "HEADER_MIXED.txt",
+                    "**/KickListener.java" to "HEADER_MIXED.txt",
+                    "**/LoginTasksQueue.java" to "HEADER_MIXED.txt",
+                    "**/MinecraftLimitedCompressDecoder.java" to "HEADER_MIXED.txt"
+                ).forEach { (pattern, licenceFile) ->
+                    matching(
+                        pattern,
+                        closureOf<LicenseProperties> {
+                            setHeader(target.rootProject.file(licenceFile))
+                        }
+                    )
+                }
+                setHeader(getHeaderFile(target))
+            }
+
+        }
+    }
+}

--- a/build-logic/convention/src/main/kotlin/net/elytrium/gradle/plugin/ModuleInfoPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/net/elytrium/gradle/plugin/ModuleInfoPlugin.kt
@@ -1,0 +1,11 @@
+package net.elytrium.gradle.plugin
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+class ModuleInfoPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        target.version = "1.1.27-SNAPSHOT"
+        target.group = "net.elytrium.limboapi"
+    }
+}

--- a/build-logic/convention/src/main/kotlin/net/elytrium/gradle/plugin/SpotBugsConfigurationPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/net/elytrium/gradle/plugin/SpotBugsConfigurationPlugin.kt
@@ -1,0 +1,30 @@
+package net.elytrium.gradle.plugin
+
+import com.github.spotbugs.snom.SpotBugsExtension
+import com.github.spotbugs.snom.SpotBugsTask
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.withType
+
+class SpotBugsConfigurationPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        target.plugins.apply("com.github.spotbugs")
+
+        target.pluginManager.withPlugin("com.github.spotbugs") {
+            target.extensions.configure<SpotBugsExtension> {
+                val suppressionsFile = target.file("${target.rootDir}/config/spotbugs/suppressions.xml")
+                excludeFilter.set(suppressionsFile)
+            }
+
+            target.tasks.withType<SpotBugsTask> {
+                reports.create("html") {
+                    required.set(true)
+                    val outputFile = target.layout.buildDirectory.file("reports/spotbugs/main/spotbugs.html")
+                    outputLocation.set(outputFile)
+                    setStylesheet("fancy-hist.xsl")
+                }
+            }
+        }
+    }
+}

--- a/build-logic/convention/src/main/kotlin/net/elytrium/gradle/plugin/revision/CurrentRevisionExtensionProvider.kt
+++ b/build-logic/convention/src/main/kotlin/net/elytrium/gradle/plugin/revision/CurrentRevisionExtensionProvider.kt
@@ -1,0 +1,21 @@
+package net.elytrium.gradle.plugin.revision
+
+open class CurrentRevisionExtensionProvider {
+    fun getCurrentShortRevision(): String {
+        val isWindows = System.getProperty("os.name")
+            .lowercase()
+            .contains("win")
+
+        val process = if (isWindows) {
+            ProcessBuilder("cmd", "/c", "git rev-parse --short HEAD")
+        } else {
+            ProcessBuilder("bash", "-c", "git rev-parse --short HEAD")
+        }
+        return process
+            .start()
+            .inputStream
+            .bufferedReader()
+            .readText()
+            .trim()
+    }
+}

--- a/build-logic/convention/src/main/kotlin/net/elytrium/gradle/plugin/revision/CurrentRevisionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/net/elytrium/gradle/plugin/revision/CurrentRevisionPlugin.kt
@@ -1,0 +1,14 @@
+package net.elytrium.gradle.plugin.revision
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.create
+
+class CurrentRevisionPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        target.extensions.create(
+            "currentShortRevisionProvider",
+            CurrentRevisionExtensionProvider::class
+        )
+    }
+}

--- a/build-logic/convention/src/main/kotlin/versionCatalog.kt
+++ b/build-logic/convention/src/main/kotlin/versionCatalog.kt
@@ -1,0 +1,9 @@
+@file:Suppress("Filename")
+
+import org.gradle.accessors.dm.LibrariesForLibs
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.the
+
+// Workaround for https://github.com/gradle/gradle/issues/15383
+val Project.libs: LibrariesForLibs
+    get() = the<LibrariesForLibs>()

--- a/build-logic/gradle/wrapper
+++ b/build-logic/gradle/wrapper
@@ -1,0 +1,1 @@
+../../gradle/wrapper

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -1,0 +1,25 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+        google()
+    }
+}
+
+dependencyResolutionManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+        google()
+    }
+
+    versionCatalogs {
+        create("libs") {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
+}
+
+rootProject.name = "build-logic"
+
+include(":convention")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,59 +6,12 @@ plugins {
     checkstyle
     alias(libs.plugins.gradle.spotbugs) apply false
     alias(libs.plugins.gradle.licenser) apply false
+    id("net.elytrium.java.version") apply false
+    id("net.elytrium.module.info") apply false
+    id("net.elytrium.revision") apply false
+    id("net.elytrium.spotbugs") apply false
+    id("net.elytrium.checkstyle") apply false
+    id("net.elytrium.licence") apply false
 }
 
-allprojects {
-    apply(plugin = "checkstyle")
-    apply(plugin = "com.github.spotbugs")
-    apply(plugin = "net.minecraftforge.licenser")
 
-    group = "net.elytrium.limboapi"
-    version = "1.1.27-SNAPSHOT"
-
-    tasks.withType<JavaCompile> {
-        sourceCompatibility = JavaVersion.VERSION_21.toString()
-        targetCompatibility = JavaVersion.VERSION_21.toString()
-    }
-
-    checkstyle {
-        toolVersion = "10.12.1"
-        configFile = file("$rootDir/config/checkstyle/checkstyle.xml")
-        configProperties = mapOf("configDirectory" to "$rootDir/config/checkstyle")
-        maxErrors = 0
-        maxWarnings = 0
-    }
-
-    extensions.configure<SpotBugsExtension> {
-        excludeFilter.set(file("${rootDir}/config/spotbugs/suppressions.xml"))
-    }
-
-    tasks.withType<SpotBugsTask>() {
-        reports.create("html") {
-            required.set(true)
-            outputLocation.set(layout.buildDirectory.file("reports/spotbugs/main/spotbugs.html"))
-            setStylesheet("fancy-hist.xsl")
-        }
-    }
-}
-
-fun getCurrentShortRevision(): String {
-    val isWindows = System.getProperty("os.name")
-        .lowercase()
-        .contains("win")
-
-    val process = if (isWindows) {
-        ProcessBuilder("cmd", "/c", "git rev-parse --short HEAD")
-    } else {
-        ProcessBuilder("bash", "-c", "git rev-parse --short HEAD")
-    }
-    return process
-        .start()
-        .inputStream
-        .bufferedReader()
-        .readText()
-        .trim()
-}
-
-// Make the function available to subprojects via extra properties
-extra["getCurrentShortRevision"] = ::getCurrentShortRevision

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,3 @@
-import com.github.spotbugs.snom.SpotBugsExtension
-import com.github.spotbugs.snom.SpotBugsTask
-
 plugins {
     java
     checkstyle

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,6 +30,8 @@ tool-google-guava = { module = "com.google.guava:guava", version.ref = "tool-goo
 tool-netty-codec = { module = "io.netty:netty-codec", version.ref = "tool-netty" }
 tool-netty-handler = { module = "io.netty:netty-handler", version.ref = "tool-netty" }
 tool-spotbugs-annotations = { module = "com.github.spotbugs:spotbugs-annotations", version.ref = "tool-spotbugs-annotations" }
+gradle-spotbugs = { module = "com.github.spotbugs:com.github.spotbugs.gradle.plugin", version.ref = "gradle-spotbugs" }
+gradle-licenser = { module = "net.minecraftforge.licenser:net.minecraftforge.licenser.gradle.plugin", version.ref = "gradle-licenser" }
 
 [plugins]
 gradle-licenser = { id = "net.minecraftforge.licenser", version.ref = "gradle-licenser" }

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -446,11 +446,6 @@ static Map<String, Integer> getBlockMappings(Object data, Map<String, Map<String
 }
 
 void generateBlockMappings(File targetDir, Map<MinecraftVersion, Object> blockReports) {
-  if (blockReports == null || blockReports.isEmpty()) {
-    logger.error("generateBlockMappings: blockReports is empty or null, skipping block mappings generation")
-    return
-  }
-
   File defaultBlockPropertiesFile = new File(targetDir, "defaultblockproperties.json")
   File blockStatesFile = new File(targetDir, "blockstates.json")
   File blockStatesMappingFile = new File(targetDir, "blockstates_mapping.json")
@@ -465,11 +460,6 @@ void generateBlockMappings(File targetDir, Map<MinecraftVersion, Object> blockRe
               [version, getDefaultProperties(report)]
             })
 
-    if (defaultProperties[MinecraftVersion.MAXIMUM_VERSION] == null) {
-      logger.error("generateBlockMappings: no data for MAXIMUM_VERSION (${MinecraftVersion.MAXIMUM_VERSION}), skipping block mappings generation")
-      return
-    }
-
     defaultBlockPropertiesFile.write(JsonOutput.prettyPrint(
             JsonOutput.toJson(defaultProperties[MinecraftVersion.MAXIMUM_VERSION].sort())), "UTF-8")
 
@@ -483,11 +473,6 @@ void generateBlockMappings(File targetDir, Map<MinecraftVersion, Object> blockRe
     })
 
     Map<String, Integer> blocks = mappings[MinecraftVersion.MAXIMUM_VERSION]
-
-    if (blocks == null) {
-      logger.error("generateBlockMappings: no block mappings for MAXIMUM_VERSION (${MinecraftVersion.MAXIMUM_VERSION}), skipping block mappings generation")
-      return
-    }
 
     blockStatesFile.write(
             JsonOutput.prettyPrint(JsonOutput.toJson(
@@ -593,11 +578,6 @@ void generateRegistryMapping(String target, File targetDir, Map<MinecraftVersion
 }
 
 void generateRegistryMappings(File targetDir, Map<MinecraftVersion, Object> registriesReports) {
-  if (registriesReports == null || registriesReports.isEmpty()) {
-    logger.error("generateRegistryMappings: registriesReports is empty or null, skipping registry mappings generation")
-    return
-  }
-
   this.generateRegistryMapping("item", targetDir, registriesReports
           .findAll({ e -> MinecraftVersion.WORLD_VERSIONS.contains(e.getKey()) }))
   this.generateRegistryMapping("block", targetDir, registriesReports)
@@ -678,11 +658,6 @@ static Map<String, Map<String, List<String>>> getTags(File tagDir, Map<String, S
 }
 
 void generateTags(File targetDir, Map<MinecraftVersion, File> tagDirs) {
-  if (tagDirs == null || tagDirs.isEmpty()) {
-    logger.error("generateTags: tagDirs is empty or null, skipping tags generation")
-    return
-  }
-
   File tagsFile = new File(targetDir, "tags.json");
   if (checkIsCacheValid(tagsFile)) {
       this.println("> Generating tags...")
@@ -732,14 +707,7 @@ tasks.register("generateMappings") {
           .dropWhile({ it < MinecraftVersion.MINECRAFT_1_13 })
           .collect(Collectors.toMap(Function.identity(), this::generateData))
 
-  Map<MinecraftVersion, Object> blockReports = generated.findAll({ version, directory ->
-    File file = new File(directory, "reports/blocks.json")
-    if (!file.exists()) {
-      logger.error("Skipping ${version}: file not found: ${file.absolutePath}")
-      return false
-    }
-    return true
-  }).collectEntries({ version, directory ->
+  Map<MinecraftVersion, Object> blockReports = generated.collectEntries({ version, directory ->
     [version, new JsonSlurper().parse(new File(directory, "reports/blocks.json"))]
   })
 
@@ -747,14 +715,6 @@ tasks.register("generateMappings") {
 
   Map<MinecraftVersion, Object> registriesReports = generated
           .findAll({ it.getKey() >= MinecraftVersion.MINECRAFT_1_14 })
-          .findAll({ version, directory ->
-            File file = new File(directory, "reports/registries.json")
-            if (!file.exists()) {
-              logger.error("Skipping ${version}: file not found: ${file.absolutePath}")
-              return false
-            }
-            return true
-          })
           .collectEntries({ version, directory ->
             [version, new JsonSlurper().parse(new File(directory, "reports/registries.json"))]
           })
@@ -762,14 +722,6 @@ tasks.register("generateMappings") {
   this.generateRegistryMappings(targetDir, registriesReports)
 
   Map<MinecraftVersion, File> tags = generated
-          .findAll({ version, directory ->
-            File file = new File(directory, "data/minecraft/tags")
-            if (!file.exists()) {
-              logger.error("Skipping ${version}: directory not found: ${file.absolutePath}")
-              return false
-            }
-            return true
-          })
           .collectEntries({ version, directory ->
             [version, new File(directory, "data/minecraft/tags")]
           })

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -10,11 +10,14 @@ buildscript() {
 plugins() {
   id("java")
   alias(libs.plugins.gradle.shadow)
-}
-
-compileJava() {
-  getOptions().getRelease().set(21)
-  getOptions().setEncoding("UTF-8")
+  alias(libs.plugins.gradle.spotbugs)
+  alias(libs.plugins.gradle.licenser)
+  id("net.elytrium.java.version")
+  id("net.elytrium.module.info")
+  id("net.elytrium.revision")
+  id("net.elytrium.spotbugs")
+  id("net.elytrium.checkstyle")
+  id("net.elytrium.licence")
 }
 
 dependencies() {
@@ -52,30 +55,6 @@ shadowJar() {
   relocate("net.elytrium.commons.velocity", "net.elytrium.limboapi.thirdparty.commons.velocity")
   relocate("net.elytrium.commons.kyori", "net.elytrium.limboapi.thirdparty.commons.kyori")
   relocate("net.elytrium.commons.config", "net.elytrium.limboapi.thirdparty.commons.config")
-}
-
-license() {
-  matching("**/mcprotocollib/**") {
-    header = rootProject.file("HEADER_MCPROTOCOLLIB.txt")
-  }
-
-  matching("**/LoginListener.java") {
-    header = rootProject.file("HEADER_MIXED.txt")
-  }
-
-  matching("**/KickListener.java") {
-    header = rootProject.file("HEADER_MIXED.txt")
-  }
-
-  matching("**/LoginTasksQueue.java") {
-    header = rootProject.file("HEADER_MIXED.txt")
-  }
-
-  matching("**/MinecraftLimitedCompressDecoder.java") {
-    header = rootProject.file("HEADER_MIXED.txt")
-  }
-
-  header = rootProject.file("HEADER.txt")
 }
 
 tasks.register("finalize") {
@@ -467,6 +446,11 @@ static Map<String, Integer> getBlockMappings(Object data, Map<String, Map<String
 }
 
 void generateBlockMappings(File targetDir, Map<MinecraftVersion, Object> blockReports) {
+  if (blockReports == null || blockReports.isEmpty()) {
+    logger.error("generateBlockMappings: blockReports is empty or null, skipping block mappings generation")
+    return
+  }
+
   File defaultBlockPropertiesFile = new File(targetDir, "defaultblockproperties.json")
   File blockStatesFile = new File(targetDir, "blockstates.json")
   File blockStatesMappingFile = new File(targetDir, "blockstates_mapping.json")
@@ -481,6 +465,11 @@ void generateBlockMappings(File targetDir, Map<MinecraftVersion, Object> blockRe
               [version, getDefaultProperties(report)]
             })
 
+    if (defaultProperties[MinecraftVersion.MAXIMUM_VERSION] == null) {
+      logger.error("generateBlockMappings: no data for MAXIMUM_VERSION (${MinecraftVersion.MAXIMUM_VERSION}), skipping block mappings generation")
+      return
+    }
+
     defaultBlockPropertiesFile.write(JsonOutput.prettyPrint(
             JsonOutput.toJson(defaultProperties[MinecraftVersion.MAXIMUM_VERSION].sort())), "UTF-8")
 
@@ -494,6 +483,11 @@ void generateBlockMappings(File targetDir, Map<MinecraftVersion, Object> blockRe
     })
 
     Map<String, Integer> blocks = mappings[MinecraftVersion.MAXIMUM_VERSION]
+
+    if (blocks == null) {
+      logger.error("generateBlockMappings: no block mappings for MAXIMUM_VERSION (${MinecraftVersion.MAXIMUM_VERSION}), skipping block mappings generation")
+      return
+    }
 
     blockStatesFile.write(
             JsonOutput.prettyPrint(JsonOutput.toJson(
@@ -599,6 +593,11 @@ void generateRegistryMapping(String target, File targetDir, Map<MinecraftVersion
 }
 
 void generateRegistryMappings(File targetDir, Map<MinecraftVersion, Object> registriesReports) {
+  if (registriesReports == null || registriesReports.isEmpty()) {
+    logger.error("generateRegistryMappings: registriesReports is empty or null, skipping registry mappings generation")
+    return
+  }
+
   this.generateRegistryMapping("item", targetDir, registriesReports
           .findAll({ e -> MinecraftVersion.WORLD_VERSIONS.contains(e.getKey()) }))
   this.generateRegistryMapping("block", targetDir, registriesReports)
@@ -679,6 +678,11 @@ static Map<String, Map<String, List<String>>> getTags(File tagDir, Map<String, S
 }
 
 void generateTags(File targetDir, Map<MinecraftVersion, File> tagDirs) {
+  if (tagDirs == null || tagDirs.isEmpty()) {
+    logger.error("generateTags: tagDirs is empty or null, skipping tags generation")
+    return
+  }
+
   File tagsFile = new File(targetDir, "tags.json");
   if (checkIsCacheValid(tagsFile)) {
       this.println("> Generating tags...")
@@ -728,7 +732,14 @@ tasks.register("generateMappings") {
           .dropWhile({ it < MinecraftVersion.MINECRAFT_1_13 })
           .collect(Collectors.toMap(Function.identity(), this::generateData))
 
-  Map<MinecraftVersion, Object> blockReports = generated.collectEntries({ version, directory ->
+  Map<MinecraftVersion, Object> blockReports = generated.findAll({ version, directory ->
+    File file = new File(directory, "reports/blocks.json")
+    if (!file.exists()) {
+      logger.error("Skipping ${version}: file not found: ${file.absolutePath}")
+      return false
+    }
+    return true
+  }).collectEntries({ version, directory ->
     [version, new JsonSlurper().parse(new File(directory, "reports/blocks.json"))]
   })
 
@@ -736,6 +747,14 @@ tasks.register("generateMappings") {
 
   Map<MinecraftVersion, Object> registriesReports = generated
           .findAll({ it.getKey() >= MinecraftVersion.MINECRAFT_1_14 })
+          .findAll({ version, directory ->
+            File file = new File(directory, "reports/registries.json")
+            if (!file.exists()) {
+              logger.error("Skipping ${version}: file not found: ${file.absolutePath}")
+              return false
+            }
+            return true
+          })
           .collectEntries({ version, directory ->
             [version, new JsonSlurper().parse(new File(directory, "reports/registries.json"))]
           })
@@ -743,6 +762,14 @@ tasks.register("generateMappings") {
   this.generateRegistryMappings(targetDir, registriesReports)
 
   Map<MinecraftVersion, File> tags = generated
+          .findAll({ version, directory ->
+            File file = new File(directory, "data/minecraft/tags")
+            if (!file.exists()) {
+              logger.error("Skipping ${version}: directory not found: ${file.absolutePath}")
+              return false
+            }
+            return true
+          })
           .collectEntries({ version, directory ->
             [version, new File(directory, "data/minecraft/tags")]
           })

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -8,16 +8,16 @@ buildscript() {
 }
 
 plugins() {
-  id("java")
+  alias(libs.plugins.gradle.licenser)
   alias(libs.plugins.gradle.shadow)
   alias(libs.plugins.gradle.spotbugs)
-  alias(libs.plugins.gradle.licenser)
+  id("java")
+  id("net.elytrium.checkstyle")
   id("net.elytrium.java.version")
+  id("net.elytrium.licence")
   id("net.elytrium.module.info")
   id("net.elytrium.revision")
   id("net.elytrium.spotbugs")
-  id("net.elytrium.checkstyle")
-  id("net.elytrium.licence")
 }
 
 dependencies() {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,7 @@
+pluginManagement {
+    includeBuild("build-logic")
+}
+
 dependencyResolutionManagement {
     repositories {
         mavenCentral()
@@ -17,4 +21,4 @@ enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 rootProject.name = "limboapi"
 
 include("api")
-include("plugin")
+//include("plugin")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -21,4 +21,4 @@ enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 rootProject.name = "limboapi"
 
 include("api")
-//include("plugin")
+include("plugin")


### PR DESCRIPTION
## Summary
PR introduces a build-logic included build with convention plugins, replacing  previous configuration approach. In addition, new setup will help to make project gradle plugins looks minimal, allows to configure the plugin-by plugin

## Changes
- Added build-logic included build with convention module containing: 
  - `id("net.elytrium.checkstyle")` - Default configuration for checkstyle
  - `id("net.elytrium.java.version")` - Configuration for JavaVersion
  - `id("net.elytrium.licence")` - Configuration for licences files
  - `id("net.elytrium.module.info")` - Configuration for version/name of modules
  - `id("net.elytrium.publish")` - Configuration for publish into maven
  - `id("net.elytrium.revision")` - Provider for current revision number
  - `id("net.elytrium.spotbugs")` - Configuration for spotbugs
- Removed `allprojects`/`subprojects` blocks, which considered anipatterns, from root build.gradle.kts