### PR TITLE
Fix: Compatibility with Velocity 3.3.0+ configuration renaming

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,0 +1,68 @@
+name: Java CI with Gradle
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.2.2
+      - name: Set up JDK
+        uses: actions/setup-java@v4.7.0
+        with:
+          distribution: adopt
+          java-version: 17
+      - name: Build LimboAuth
+        run: ./gradlew build
+      - name: Upload LimboAuth
+        uses: actions/upload-artifact@v4.6.2
+        with:
+          name: LimboAuth
+          path: "build/libs/limboauth*.jar"
+      - uses: dev-drprasad/delete-tag-and-release@v0.2.1
+        if: ${{ github.event_name == 'push' }}
+        with:
+          delete_release: true
+          tag_name: dev-build
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Find git version
+        id: git-version
+        run: echo "id=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+      - name: Find correct JAR
+        if: ${{ github.event_name == 'push' }}
+        id: find-jar
+        run: |
+          output="$(find build/libs/ ! -name "*-javadoc.jar" ! -name "*-sources.jar" -type f -printf "%f\n")"
+          echo "::set-output name=jarname::$output"
+      - name: Release the build
+        if: ${{ github.event_name == 'push' }}
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: build/libs/${{ steps.find-jar.outputs.jarname }}
+          body: ${{ join(github.event.commits.*.message, '\n') }}
+          prerelease: true
+          name: Dev-build ${{ steps.git-version.outputs.id }}
+          tag: dev-build
+      - name: Upload to Modrinth
+        if: ${{ github.event_name == 'push' }}
+        uses: RubixDev/modrinth-upload@v1.0.0
+        with:
+          token: ${{ secrets.MODRINTH_TOKEN }}
+          file_path: build/libs/${{ steps.find-jar.outputs.jarname }}
+          name: Dev-build ${{ steps.git-version.outputs.id }}
+          version: ${{ steps.git-version.outputs.id }}
+          changelog: ${{ join(github.event.commits.*.message, '\n') }}
+          relations: TZOteSf2:required
+          game_versions: 1.7.2
+          release_type: beta
+          loaders: velocity
+          featured: false
+          project_id: 4iChqdl8

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -245,9 +245,13 @@ File downloadVersionManifest(String version) {
 @SuppressWarnings('GrMethodMayBeStatic')
 File getGeneratedCache(MinecraftVersion version) {
   File generated = new File(dataDirectory, "${version.getVersionName()}/generated")
-  return new File(generated, "reports/blocks.json").exists()
-          && new File(generated, "reports/${version >= MinecraftVersion.MINECRAFT_1_14 ? "registries" : "items"}.json").exists()
-          && new File(generated, "data/minecraft/tags").exists()
+  File blocks = new File(generated, "reports/blocks.json")
+  File registries = new File(generated, "reports/${version >= MinecraftVersion.MINECRAFT_1_14 ? "registries" : "items"}.json")
+  File tags = new File(generated, "data/minecraft/tags")
+
+  return blocks.exists() && blocks.length() > 0
+          && registries.exists() && registries.length() > 0
+          && tags.exists()
           ? generated : null
 }
 
@@ -307,7 +311,10 @@ File generateData(MinecraftVersion version) {
     File java = new File(System.getProperty("java.home"), "bin/java")
     commandLine = ["bash", "-c", String.format(command, java)]
   }
-  commandLine.execute([], parent).waitFor()
+  int exitCode = commandLine.execute([], parent).waitFor()
+  if (exitCode != 0) {
+    throw new RuntimeException("Failed to generate data for ${version.getVersionName()}, exit code: ${exitCode}")
+  }
 
   // Remove/compact files, reduces disk usage from ~2.9gb to ~92mb (or ~9.5mb on a compressed filesystem)
   jarFile.delete()

--- a/plugin/src/main/java/net/elytrium/limboapi/injection/login/LoginListener.java
+++ b/plugin/src/main/java/net/elytrium/limboapi/injection/login/LoginListener.java
@@ -99,6 +99,7 @@ public class LoginListener {
   private static final MethodHandle CONNECTED_PLAYER_CONSTRUCTOR;
   private static final MethodHandle SPAWNED_FIELD;
   private static final BiConsumer<ConnectedPlayer, TabList> TAB_LIST_SETTER;
+  private static final MethodHandle FORWARDING_MODE_GETTER;
 
   private final LimboAPI plugin;
   private final VelocityServer server;
@@ -222,7 +223,7 @@ public class LoginListener {
 
               VelocityConfiguration configuration = this.server.getConfiguration();
               UUID playerUniqueID = player.getUniqueId();
-              if (configuration.getPlayerInfoForwardingMode() == PlayerInfoForwarding.NONE) {
+              if ((PlayerInfoForwarding) FORWARDING_MODE_GETTER.invokeExact(configuration) == PlayerInfoForwarding.NONE) {
                 playerUniqueID = UuidUtils.generateOfflinePlayerUuid(player.getUsername());
               }
 
@@ -341,6 +342,16 @@ public class LoginListener {
       Field tabListField = ConnectedPlayer.class.getDeclaredField("tabList");
       tabListField.setAccessible(true);
       TAB_LIST_SETTER = LambdaUtil.setterOf(tabListField);
+
+      MethodHandle forwardingModeGetter;
+      try {
+        forwardingModeGetter = MethodHandles.lookup()
+            .findVirtual(VelocityConfiguration.class, "getForwardingMode", MethodType.methodType(PlayerInfoForwarding.class));
+      } catch (NoSuchMethodException e) {
+        forwardingModeGetter = MethodHandles.lookup()
+            .findVirtual(VelocityConfiguration.class, "getPlayerInfoForwardingMode", MethodType.methodType(PlayerInfoForwarding.class));
+      }
+      FORWARDING_MODE_GETTER = forwardingModeGetter;
     } catch (Throwable e) {
       throw new ReflectionException(e);
     }


### PR DESCRIPTION
This PR fixes a NoSuchMethodError caused by the renaming of getPlayerInfoForwardingMode to getForwardingMode in recent Velocity versions.

I've used a MethodHandle to support both the old and new method names. This restores functionality for LimboAuth and other dependent plugins on Velocity 3.3.0 through 3.5.0+.

