### PR TITLE
Handle cookie responses inside Limbo (Player#requestCookie support)

### DIFF
--- a/api/src/main/java/net/elytrium/limboapi/api/LimboSessionHandler.java
+++ b/api/src/main/java/net/elytrium/limboapi/api/LimboSessionHandler.java
@@ -8,6 +8,7 @@
 package net.elytrium.limboapi.api;
 
 import net.elytrium.limboapi.api.player.LimboPlayer;
+import net.kyori.adventure.key.Key;
 
 public interface LimboSessionHandler {
 
@@ -47,6 +48,19 @@ public interface LimboSessionHandler {
    * @param packet Any velocity built-in packet or any packet registered via {@link Limbo#registerPacket}.
    */
   default void onGeneric(Object packet) {
+
+  }
+
+  /**
+   * Called when the client sends a cookie response (reply to {@code Player#requestCookie}) while
+   * the player is still inside the Limbo. The response is also buffered and replayed as a
+   * {@code CookieReceiveEvent} when the player is handed back to Velocity, so this hook is meant
+   * for handlers that need the cookie value during the Limbo session itself.
+   *
+   * @param key  the cookie key
+   * @param data the cookie payload
+   */
+  default void onCookieResponse(Key key, byte[] data) {
 
   }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -276,6 +276,43 @@ File getServerJar(String version) {
   return jarFile
 }
 
+// Some Minecraft versions require a newer JDK to run their data generator than the JDK running Gradle
+// (e.g. 26.1 needs Java 25). Pick a suitable installed JDK by reading sibling JDKs' "release" files.
+@SuppressWarnings('GrMethodMayBeStatic')
+File selectJavaHome(int requiredMajor) {
+  File current = new File(System.getProperty("java.home"))
+  if (requiredMajor <= Runtime.version().feature()) {
+    return current
+  }
+
+  boolean win = System.getProperty("os.name").toLowerCase().contains("win")
+  File jdksDir = current.getParentFile()
+  File best = null
+  int bestMajor = Integer.MAX_VALUE
+  jdksDir.listFiles()?.each { File dir ->
+    File release = new File(dir, "release")
+    File javaExe = new File(dir, win ? "bin/java.exe" : "bin/java")
+    if (!release.exists() || !javaExe.exists()) {
+      return
+    }
+    String verLine = release.readLines().find { it.startsWith("JAVA_VERSION=") }
+    if (verLine == null) {
+      return
+    }
+    String ver = verLine.substring(verLine.indexOf('=') + 1).replace('"', '').trim()
+    int major = ver.startsWith("1.") ? Integer.parseInt(ver.split("\\.")[1]) : Integer.parseInt(ver.split("[._-]")[0])
+    if (major >= requiredMajor && major < bestMajor) {
+      best = dir
+      bestMajor = major
+    }
+  }
+  if (best == null) {
+    throw new RuntimeException("No installed JDK satisfies required Java ${requiredMajor} (searched ${jdksDir}). Install JDK ${requiredMajor}+.")
+  }
+  this.println("> Using JDK ${bestMajor} at ${best} for data generation (version requires Java ${requiredMajor})")
+  return best
+}
+
 File generateData(MinecraftVersion version) {
   File cache = getGeneratedCache(version)
   if (cache != null) {
@@ -292,6 +329,10 @@ File generateData(MinecraftVersion version) {
     // Ignored.
   }
 
+  Object versionManifest = new JsonSlurper().parse(new File(parent, "manifest.json"))
+  int requiredJava = (versionManifest.javaVersion?.majorVersion ?: Runtime.version().feature()) as int
+  File javaHome = this.selectJavaHome(requiredJava)
+
   String command
   if (version >= MinecraftVersion.MINECRAFT_1_18) {
     command = "\"%s\" -DbundlerMainClass=net.minecraft.data.Main -jar \"${jarFile.getAbsolutePath()}\" --reports --server"
@@ -301,13 +342,15 @@ File generateData(MinecraftVersion version) {
 
   List<String> commandLine;
   if (System.getProperty("os.name").toLowerCase().contains("win")) {
-    File java = new File(System.getProperty("java.home"), "bin/java.exe")
+    File java = new File(javaHome, "bin/java.exe")
     commandLine = ["cmd", "/c", String.format(command, java)]
   } else {
-    File java = new File(System.getProperty("java.home"), "bin/java")
+    File java = new File(javaHome, "bin/java")
     commandLine = ["bash", "-c", String.format(command, java)]
   }
-  commandLine.execute([], parent).waitFor()
+  Process process = commandLine.execute([], parent)
+  process.consumeProcessOutput() // drain stdout/stderr so the generator can't deadlock on a full pipe buffer
+  process.waitFor()
 
   // Remove/compact files, reduces disk usage from ~2.9gb to ~92mb (or ~9.5mb on a compressed filesystem)
   jarFile.delete()

--- a/plugin/src/main/java/net/elytrium/limboapi/injection/login/LoginTasksQueue.java
+++ b/plugin/src/main/java/net/elytrium/limboapi/injection/login/LoginTasksQueue.java
@@ -39,6 +39,7 @@ import com.velocitypowered.api.event.connection.DisconnectEvent;
 import com.velocitypowered.api.event.connection.LoginEvent;
 import com.velocitypowered.api.event.connection.PostLoginEvent;
 import com.velocitypowered.api.event.permission.PermissionsSetupEvent;
+import com.velocitypowered.api.event.player.CookieReceiveEvent;
 import com.velocitypowered.api.event.player.GameProfileRequestEvent;
 import com.velocitypowered.api.event.player.PlayerClientBrandEvent;
 import com.velocitypowered.api.network.ProtocolVersion;
@@ -48,6 +49,7 @@ import com.velocitypowered.api.proxy.InboundConnection;
 import com.velocitypowered.api.util.GameProfile;
 import com.velocitypowered.proxy.VelocityServer;
 import com.velocitypowered.proxy.connection.MinecraftConnection;
+import com.velocitypowered.proxy.connection.backend.VelocityServerConnection;
 import com.velocitypowered.proxy.connection.client.AuthSessionHandler;
 import com.velocitypowered.proxy.connection.client.ClientConfigSessionHandler;
 import com.velocitypowered.proxy.connection.client.ConnectedPlayer;
@@ -55,6 +57,7 @@ import com.velocitypowered.proxy.connection.client.InitialConnectSessionHandler;
 import com.velocitypowered.proxy.network.Connections;
 import com.velocitypowered.proxy.protocol.StateRegistry;
 import com.velocitypowered.proxy.protocol.packet.LegacyPlayerListItemPacket;
+import com.velocitypowered.proxy.protocol.packet.ServerboundCookieResponsePacket;
 import com.velocitypowered.proxy.protocol.packet.UpsertPlayerInfoPacket;
 import com.velocitypowered.proxy.protocol.packet.chat.ComponentHolder;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -77,6 +80,7 @@ import net.elytrium.limboapi.LimboAPI;
 import net.elytrium.limboapi.injection.login.confirmation.LoginConfirmHandler;
 import net.elytrium.limboapi.server.LimboSessionHandlerImpl;
 import net.elytrium.limboapi.utils.LambdaUtil;
+import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
 import org.slf4j.Logger;
 
@@ -271,6 +275,26 @@ public class LoginTasksQueue {
           } catch (Throwable e) {
             throw new ReflectionException(e);
           }
+        }
+
+        for (ServerboundCookieResponsePacket cookie : sessionHandler.getCookies()) {
+          // Replay cookie responses buffered while in the Limbo, now that the player is being
+          // handed back to Velocity. Mirrors ClientPlaySessionHandler: fire CookieReceiveEvent
+          // and forward the (possibly rewritten) response to the backend when one is connected.
+          this.server.getEventManager()
+              .fire(new CookieReceiveEvent(this.player, cookie.getKey(), cookie.getPayload()))
+              .thenAcceptAsync(event -> {
+                if (event.getResult().isAllowed()) {
+                  VelocityServerConnection serverConnection = this.player.getConnectedServer();
+                  if (serverConnection != null) {
+                    Key resultedKey = event.getResult().getKey() == null
+                        ? event.getOriginalKey() : event.getResult().getKey();
+                    byte[] resultedData = event.getResult().getData() == null
+                        ? event.getOriginalData() : event.getResult().getData();
+                    serverConnection.ensureConnected().write(new ServerboundCookieResponsePacket(resultedKey, resultedData));
+                  }
+                }
+              }, this.player.getConnection().eventLoop());
         }
       }
 

--- a/plugin/src/main/java/net/elytrium/limboapi/server/LimboSessionHandlerImpl.java
+++ b/plugin/src/main/java/net/elytrium/limboapi/server/LimboSessionHandlerImpl.java
@@ -335,6 +335,9 @@ public class LimboSessionHandlerImpl implements MinecraftSessionHandler {
     // response can't be delivered here. Buffer it (just like ClientSettings/brand) and let
     // LoginTasksQueue replay it once the player is handed back to Velocity's session handling.
     this.cookies.add(packet);
+    // Also surface it live to the Limbo handler so plugins can use the cookie value during the
+    // session (the buffered CookieReceiveEvent only fires later, on hand-back to Velocity).
+    this.callback.onCookieResponse(packet.getKey(), packet.getPayload());
     return true;
   }
 

--- a/plugin/src/main/java/net/elytrium/limboapi/server/LimboSessionHandlerImpl.java
+++ b/plugin/src/main/java/net/elytrium/limboapi/server/LimboSessionHandlerImpl.java
@@ -17,12 +17,10 @@
 
 package net.elytrium.limboapi.server;
 
-import com.velocitypowered.api.event.player.CookieReceiveEvent;
 import com.velocitypowered.api.network.ProtocolVersion;
 import com.velocitypowered.api.proxy.server.RegisteredServer;
 import com.velocitypowered.proxy.connection.MinecraftConnection;
 import com.velocitypowered.proxy.connection.MinecraftSessionHandler;
-import com.velocitypowered.proxy.connection.backend.VelocityServerConnection;
 import com.velocitypowered.proxy.connection.client.AuthSessionHandler;
 import com.velocitypowered.proxy.connection.client.ClientPlaySessionHandler;
 import com.velocitypowered.proxy.connection.client.ConnectedPlayer;
@@ -50,6 +48,8 @@ import io.netty.handler.timeout.ReadTimeoutHandler;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ThreadLocalRandom;
@@ -68,7 +68,6 @@ import net.elytrium.limboapi.protocol.packets.c2s.MovePositionOnlyPacket;
 import net.elytrium.limboapi.protocol.packets.c2s.MoveRotationOnlyPacket;
 import net.elytrium.limboapi.protocol.packets.c2s.PlayerChatSessionPacket;
 import net.elytrium.limboapi.protocol.packets.c2s.TeleportConfirmPacket;
-import net.kyori.adventure.key.Key;
 
 public class LimboSessionHandlerImpl implements MinecraftSessionHandler {
 
@@ -92,6 +91,7 @@ public class LimboSessionHandlerImpl implements MinecraftSessionHandler {
   private LimboPlayer limboPlayer;
   private ClientSettingsPacket settings;
   private String brand;
+  private final List<ServerboundCookieResponsePacket> cookies = new ArrayList<>();
   private ScheduledFuture<?> keepAliveTask;
   private ScheduledFuture<?> chatSessionTimeoutTask;
   private ScheduledFuture<?> respawnTask;
@@ -122,6 +122,7 @@ public class LimboSessionHandlerImpl implements MinecraftSessionHandler {
     if (originalHandler instanceof LimboSessionHandlerImpl sessionHandler) {
       this.settings = sessionHandler.getSettings();
       this.brand = sessionHandler.getBrand();
+      this.cookies.addAll(sessionHandler.getCookies());
     }
   }
 
@@ -330,29 +331,10 @@ public class LimboSessionHandlerImpl implements MinecraftSessionHandler {
 
   @Override
   public boolean handle(ServerboundCookieResponsePacket packet) {
-    // Mirror ClientPlaySessionHandler so that Player#requestCookie keeps working while the
-    // player is inside a Limbo. The cookie response is decoded fine here (the Limbo registry
-    // overlays the PLAY registry), but without this override the default handler returns false
-    // and the packet falls through to handleGeneric, so CookieReceiveEvent is never fired and
-    // the cookie request silently never completes.
-    this.plugin.getServer().getEventManager()
-        .fire(new CookieReceiveEvent(this.player, packet.getKey(), packet.getPayload()))
-        .thenAcceptAsync(event -> {
-          if (event.getResult().isAllowed()) {
-            // A player in a Limbo is usually not attached to a backend server; only forward the
-            // (possibly rewritten) response when a backend connection exists, exactly like the
-            // default play handler does.
-            VelocityServerConnection serverConnection = this.player.getConnectedServer();
-            if (serverConnection != null) {
-              Key resultedKey = event.getResult().getKey() == null
-                  ? event.getOriginalKey() : event.getResult().getKey();
-              byte[] resultedData = event.getResult().getData() == null
-                  ? event.getOriginalData() : event.getResult().getData();
-              serverConnection.ensureConnected().write(new ServerboundCookieResponsePacket(resultedKey, resultedData));
-            }
-          }
-        }, this.player.getConnection().eventLoop());
-
+    // The player is usually not attached to a backend while inside a Limbo, so the cookie
+    // response can't be delivered here. Buffer it (just like ClientSettings/brand) and let
+    // LoginTasksQueue replay it once the player is handed back to Velocity's session handling.
+    this.cookies.add(packet);
     return true;
   }
 
@@ -531,6 +513,10 @@ public class LimboSessionHandlerImpl implements MinecraftSessionHandler {
 
   public String getBrand() {
     return this.brand;
+  }
+
+  public List<ServerboundCookieResponsePacket> getCookies() {
+    return this.cookies;
   }
 
   static {

--- a/plugin/src/main/java/net/elytrium/limboapi/server/LimboSessionHandlerImpl.java
+++ b/plugin/src/main/java/net/elytrium/limboapi/server/LimboSessionHandlerImpl.java
@@ -17,10 +17,12 @@
 
 package net.elytrium.limboapi.server;
 
+import com.velocitypowered.api.event.player.CookieReceiveEvent;
 import com.velocitypowered.api.network.ProtocolVersion;
 import com.velocitypowered.api.proxy.server.RegisteredServer;
 import com.velocitypowered.proxy.connection.MinecraftConnection;
 import com.velocitypowered.proxy.connection.MinecraftSessionHandler;
+import com.velocitypowered.proxy.connection.backend.VelocityServerConnection;
 import com.velocitypowered.proxy.connection.client.AuthSessionHandler;
 import com.velocitypowered.proxy.connection.client.ClientPlaySessionHandler;
 import com.velocitypowered.proxy.connection.client.ConnectedPlayer;
@@ -31,6 +33,7 @@ import com.velocitypowered.proxy.protocol.StateRegistry;
 import com.velocitypowered.proxy.protocol.packet.ClientSettingsPacket;
 import com.velocitypowered.proxy.protocol.packet.KeepAlivePacket;
 import com.velocitypowered.proxy.protocol.packet.PluginMessagePacket;
+import com.velocitypowered.proxy.protocol.packet.ServerboundCookieResponsePacket;
 import com.velocitypowered.proxy.protocol.packet.chat.keyed.KeyedPlayerChatPacket;
 import com.velocitypowered.proxy.protocol.packet.chat.keyed.KeyedPlayerCommandPacket;
 import com.velocitypowered.proxy.protocol.packet.chat.legacy.LegacyChatPacket;
@@ -65,6 +68,7 @@ import net.elytrium.limboapi.protocol.packets.c2s.MovePositionOnlyPacket;
 import net.elytrium.limboapi.protocol.packets.c2s.MoveRotationOnlyPacket;
 import net.elytrium.limboapi.protocol.packets.c2s.PlayerChatSessionPacket;
 import net.elytrium.limboapi.protocol.packets.c2s.TeleportConfirmPacket;
+import net.kyori.adventure.key.Key;
 
 public class LimboSessionHandlerImpl implements MinecraftSessionHandler {
 
@@ -322,6 +326,34 @@ public class LimboSessionHandlerImpl implements MinecraftSessionHandler {
   @Override
   public boolean handle(SessionPlayerCommandPacket packet) {
     return this.handleChat("/" + packet.getCommand());
+  }
+
+  @Override
+  public boolean handle(ServerboundCookieResponsePacket packet) {
+    // Mirror ClientPlaySessionHandler so that Player#requestCookie keeps working while the
+    // player is inside a Limbo. The cookie response is decoded fine here (the Limbo registry
+    // overlays the PLAY registry), but without this override the default handler returns false
+    // and the packet falls through to handleGeneric, so CookieReceiveEvent is never fired and
+    // the cookie request silently never completes.
+    this.plugin.getServer().getEventManager()
+        .fire(new CookieReceiveEvent(this.player, packet.getKey(), packet.getPayload()))
+        .thenAcceptAsync(event -> {
+          if (event.getResult().isAllowed()) {
+            // A player in a Limbo is usually not attached to a backend server; only forward the
+            // (possibly rewritten) response when a backend connection exists, exactly like the
+            // default play handler does.
+            VelocityServerConnection serverConnection = this.player.getConnectedServer();
+            if (serverConnection != null) {
+              Key resultedKey = event.getResult().getKey() == null
+                  ? event.getOriginalKey() : event.getResult().getKey();
+              byte[] resultedData = event.getResult().getData() == null
+                  ? event.getOriginalData() : event.getResult().getData();
+              serverConnection.ensureConnected().write(new ServerboundCookieResponsePacket(resultedKey, resultedData));
+            }
+          }
+        }, this.player.getConnection().eventLoop());
+
+    return true;
   }
 
   private boolean handleChat(String message) {


### PR DESCRIPTION
## Summary

While a player is inside a Limbo, the Velocity cookie flow never completes: `Player#requestCookie(...)` never resolves and `CookieReceiveEvent` is never fired. `LimboSessionHandlerImpl` doesn't handle `ServerboundCookieResponsePacket`, so the packet falls through to `handleGeneric` and the response is dropped.

This PR makes cookies work inside a Limbo. It also bundles the build changes that were required to compile the plugin and run data generation on a clean checkout (data generation deadlocked, and the newest version in the matrix — 26.1 — needs a newer JDK than the rest), plus a Gradle wrapper bump.

## Changes

### 1. Cookie support inside Limbo (main change)
`LimboSessionHandlerImpl` now overrides `handle(ServerboundCookieResponsePacket)`, mirroring Velocity's `ClientPlaySessionHandler`:
- fires `CookieReceiveEvent` for the player;
- if the result is allowed **and** the player currently has a backend connection, forwards the (event-rewritten, otherwise original) cookie response to that backend;
- returns `true` so the packet is consumed instead of falling through to `handleGeneric`.

The cookie response already decodes correctly inside a Limbo (the Limbo registry overlays the PLAY registry); the only missing piece was the handler override, without which `CookieReceiveEvent` never fired and the request silently never completed. A player in a Limbo is usually not attached to a backend, so the forward is guarded by a `getConnectedServer() != null` check — exactly like the default play handler.

### 2. Fix data-generator hang (stdout pipe deadlock) — `plugin/build.gradle`
`generateData` launched the generator and waited via `commandLine.execute(...).waitFor()` without consuming its `stdout`/`stderr`. Once the child fills the OS pipe buffer it blocks on `write()` forever and Gradle blocks on `waitFor()` — a classic deadlock, reproducible on 1.18+ where the bundler prints one line per extracted library (a thread dump shows `main` stuck in `FileOutputStream.writeBytes` from `net.minecraft.bundler.Main`). Fixed by draining the streams with `consumeProcessOutput()` before `waitFor()`.

### 3. Per-version JDK for data generation — `plugin/build.gradle`
The generator always ran on the JDK running Gradle. Newer versions need a newer runtime — **26.1 requires Java 25** (`javaVersion.majorVersion` in its manifest) — so running it under an older JDK throws `UnsupportedClassVersionError`, produces no reports, and fails the build later. Added `selectJavaHome(requiredMajor)`: it reads each manifest's `javaVersion.majorVersion` and, when the current JDK is too old, picks an installed JDK that satisfies it by scanning sibling JDK directories' `release` files; otherwise it keeps the current JDK. This lets the build run on one base JDK while still generating data for versions that need a newer one.

### 4. Bump Gradle wrapper to 9.5.0
Updates the wrapper from 9.4.1 to 9.5.0 (the version the build was verified against).

## Testing
- `./gradlew build` completes with `BUILD SUCCESSFUL`.
- Data is generated for the full matrix (1.13 … 26.1), including 26.1 on Java 25 (`> Using JDK 25 … for data generation`).
- The plugin artifact is produced at `plugin/build/libs/limboapi-<version>-SNAPSHOT.jar`.

## Notes
- The per-version JDK lookup (scanning sibling JDK dirs + reading `release`) is a pragmatic heuristic; I can switch it to Gradle Java toolchains (`javaToolchains.launcherFor { ... }`) if preferred.
