### PR TITLE
Support latest Velocity (protocol 776 / Minecraft 26.2)

### DIFF
--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -149,7 +149,7 @@ enum MinecraftVersion {
   MINECRAFT_1_21_7(772),
   MINECRAFT_1_21_9(773),
   MINECRAFT_1_21_11(774),
-  MINECRAFT_26_1(774)
+  MINECRAFT_26_1(775)
 
   public static final List<MinecraftVersion> WORLD_VERSIONS = List.of(
     MINECRAFT_1_13,

--- a/plugin/src/main/java/net/elytrium/limboapi/LimboAPI.java
+++ b/plugin/src/main/java/net/elytrium/limboapi/LimboAPI.java
@@ -130,7 +130,7 @@ import org.slf4j.Logger;
 )
 public class LimboAPI implements LimboFactory {
 
-  private static final int SUPPORTED_MAXIMUM_PROTOCOL_VERSION_NUMBER = 775;
+  private static final int SUPPORTED_MAXIMUM_PROTOCOL_VERSION_NUMBER = 776;
 
   @MonotonicNonNull
   private static Logger LOGGER;


### PR DESCRIPTION
- Bump SUPPORTED_MAXIMUM_PROTOCOL_VERSION_NUMBER 775 -> 776 so LimboAPI recognizes ProtocolVersion.MINECRAFT_26_2 (the new MAXIMUM_VERSION in velocity-api 3.5.0-SNAPSHOT) instead of warning/shutting down.
- Fix MinecraftVersion enum: MINECRAFT_26_1 protocol number 774 -> 775 to match Velocity (MINECRAFT_1_21_11 is 774, MINECRAFT_26_1 is 775).

No packet-mapping changes needed: Velocity did not shift any packet IDs for 1.21.11/26.2, and LimboAPI's mappings already extend from MINECRAFT_26_1 up to MAXIMUM_VERSION via range semantics, so 26.2 is covered automatically