### PR TITLE
fix: correct BlockEntityVersion range for MC 26.2 to fix dependency resolution

### DIFF
--- a/api/src/main/java/net/elytrium/limboapi/api/chunk/BlockEntityVersion.java
+++ b/api/src/main/java/net/elytrium/limboapi/api/chunk/BlockEntityVersion.java
@@ -33,7 +33,7 @@ public enum BlockEntityVersion {
   MINECRAFT_1_21_7(EnumSet.of(ProtocolVersion.MINECRAFT_1_21_7)),
   MINECRAFT_1_21_9(EnumSet.of(ProtocolVersion.MINECRAFT_1_21_9)),
   MINECRAFT_1_21_11(EnumSet.of(ProtocolVersion.MINECRAFT_1_21_11)),
-  MINECRAFT_26_1(EnumSet.of(ProtocolVersion.MINECRAFT_26_1));
+  MINECRAFT_26_1(EnumSet.range(ProtocolVersion.MINECRAFT_26_1, ProtocolVersion.MAXIMUM_VERSION));
 
   private static final EnumMap<ProtocolVersion, BlockEntityVersion> MC_VERSION_TO_ITEM_VERSIONS = new EnumMap<>(ProtocolVersion.class);
   private static final Map<String, BlockEntityVersion> KEY_LOOKUP = Map.copyOf(EnumUniverse.createProtocolLookup(values()));

--- a/api/src/main/java/net/elytrium/limboapi/api/chunk/BlockEntityVersion.java
+++ b/api/src/main/java/net/elytrium/limboapi/api/chunk/BlockEntityVersion.java
@@ -33,7 +33,8 @@ public enum BlockEntityVersion {
   MINECRAFT_1_21_7(EnumSet.of(ProtocolVersion.MINECRAFT_1_21_7)),
   MINECRAFT_1_21_9(EnumSet.of(ProtocolVersion.MINECRAFT_1_21_9)),
   MINECRAFT_1_21_11(EnumSet.of(ProtocolVersion.MINECRAFT_1_21_11)),
-  MINECRAFT_26_1(EnumSet.range(ProtocolVersion.MINECRAFT_26_1, ProtocolVersion.MAXIMUM_VERSION));
+  MINECRAFT_26_1(EnumSet.of(ProtocolVersion.MINECRAFT_26_1)),
+  MINECRAFT_26_2(EnumSet.range(ProtocolVersion.MINECRAFT_26_2, ProtocolVersion.MAXIMUM_VERSION));
 
   private static final EnumMap<ProtocolVersion, BlockEntityVersion> MC_VERSION_TO_ITEM_VERSIONS = new EnumMap<>(ProtocolVersion.class);
   private static final Map<String, BlockEntityVersion> KEY_LOOKUP = Map.copyOf(EnumUniverse.createProtocolLookup(values()));


### PR DESCRIPTION
Fixed an issue where downstream plugins (such as `LimboAuth`) fail to depend on LimboAPI when running on Minecraft 26.2. 

This was caused by the `BlockEntityVersion` range being outdated for 26.2. This PR updates the version range to ensure that dependency resolution works correctly for dependent plugins on this Minecraft version.