### PR TITLE
Fix direct Forge connection (Issue #89)

### DIFF
--- a/plugin/src/main/java/net/elytrium/limboapi/injection/login/LoginListener.java
+++ b/plugin/src/main/java/net/elytrium/limboapi/injection/login/LoginListener.java
@@ -112,9 +112,8 @@ public class LoginListener {
   public void hookInitialServer(PlayerChooseInitialServerEvent event) {
     if (this.plugin.hasNextServer(event.getPlayer())) {
       event.setInitialServer(this.plugin.getNextServer(event.getPlayer()));
+      this.plugin.setLimboJoined(event.getPlayer());
     }
-
-    this.plugin.setLimboJoined(event.getPlayer());
   }
 
   @SuppressWarnings("ConstantConditions")


### PR DESCRIPTION
Fixes #89.  
Move `setLimboJoined` call in `PlayerChooseInitialServerEvent` to only when the player is actually being sent to a Limbo (i.e. `nextServer` is present). This prevents premature `onFirstJoin` for Forge clients that connect directly, avoiding the `ClassCastException` with `HandshakeReset`/`ServerHello`. The call is already performed later in `spawnPlayerLocal` when the player enters Limbo, and for non-Limbo connections the phase initialisation happens naturally via the play session handler.